### PR TITLE
 API-422: Use the API to create a draft in tests 

### DIFF
--- a/tests/Common/Api/ProductDrafts/AbstractProductDraftApiTestCase.php
+++ b/tests/Common/Api/ProductDrafts/AbstractProductDraftApiTestCase.php
@@ -14,23 +14,6 @@ use Akeneo\PimEnterprise\tests\Common\Api\ApiTestCase;
 abstract class AbstractProductDraftApiTestCase extends ApiTestCase
 {
     /**
-     * Creates a product draft, incarnating a specified user.
-     *
-     * @param string $identifier
-     * @param array  $data
-     * @param string $user
-     */
-    protected function createDraft($identifier, array $data, $user)
-    {
-        $this->getCommandLauncher()->launch(sprintf(
-            'pim:draft:create %s \'%s\' %s',
-            $identifier,
-            json_encode($data),
-            $user
-        ));
-    }
-
-    /**
      * Replaces changing data by specified values.
      *
      * @param array $productDraftData

--- a/tests/Common/Api/ProductDrafts/GetProductDraftApiIntegration.php
+++ b/tests/Common/Api/ProductDrafts/GetProductDraftApiIntegration.php
@@ -21,18 +21,18 @@ class GetProductDraftApiIntegration extends AbstractProductDraftApiTestCase
 
     public function testGet()
     {
-        $this->createDraft(
-            'big_boot',
-            [
-                [
-                    'type' => 'set_data',
-                    'field' => 'name',
-                    'data' => 'My new name, just for this draft',
-                    'locale' => 'en_US',
+        $productApi = $this->createClient('Sandra', 'Sandra')->getProductApi();
+        $productApi->upsert('big_boot', [
+            'values' => [
+                'name' => [
+                    [
+                        'data' => 'A new name to create a draft',
+                        'locale' => 'en_US',
+                        'scope' => null,
+                    ],
                 ],
             ],
-            'Sandra'
-        );
+        ]);
 
         $expectedProductDraft = [
             'identifier' => 'big_boot',
@@ -118,7 +118,7 @@ class GetProductDraftApiIntegration extends AbstractProductDraftApiTestCase
                     [
                         'locale' => 'en_US',
                         'scope' => null,
-                        'data' => 'My new name, just for this draft',
+                        'data' => 'A new name to create a draft',
                     ],
                 ],
             ],
@@ -162,20 +162,20 @@ class GetProductDraftApiIntegration extends AbstractProductDraftApiTestCase
      */
     public function testCannotGetIfNoRightAccess()
     {
-        $this->createDraft(
-            'big_boot',
-            [
-                [
-                    'type' => 'set_data',
-                    'field' => 'name',
-                    'data' => 'My new name, just for this draft',
-                    'locale' => 'en_US',
+        $productApi = $this->createClient('Sandra', 'Sandra')->getProductApi();
+        $productApi->upsert('big_boot', [
+            'values' => [
+                'name' => [
+                    [
+                        'data' => 'A new name to create a draft',
+                        'locale' => 'en_US',
+                        'scope' => null,
+                    ],
                 ],
             ],
-            'Sandra'
-        );
+        ]);
 
-        $api = $this->createClient('Mary', 'Mary')->getProductDraftApi();
-        $api->get('big_boot');
+        $productDraftApi = $this->createClient('Mary', 'Mary')->getProductDraftApi();
+        $productDraftApi->get('big_boot');
     }
 }


### PR DESCRIPTION
A user will create a draft with the API if he/she try to update a product he/she can edit but doesn't own.

This PR tests the draft creation by using the API rather than the console command `pim:draft:create`.