### PR TITLE
Fix type returned when downloading a reference entity media file

### DIFF
--- a/src/Api/ReferenceEntityMediaFileApiInterface.php
+++ b/src/Api/ReferenceEntityMediaFileApiInterface.php
@@ -4,17 +4,28 @@ declare(strict_types=1);
 
 namespace Akeneo\PimEnterprise\ApiClient\Api;
 
-use Akeneo\Pim\ApiClient\Api\Operation\DownloadableResourceInterface;
 use Akeneo\Pim\ApiClient\Exception\HttpException;
 use Akeneo\Pim\ApiClient\Exception\RuntimeException;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @author    Laurent Petard <laurent.petard@akeneo.com>
  * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-interface ReferenceEntityMediaFileApiInterface extends DownloadableResourceInterface
+interface ReferenceEntityMediaFileApiInterface
 {
+    /**
+     * Downloads a reference entity media file by its code
+     *
+     * @param string $code Code of the media file
+     *
+     * @throws HttpException If the request failed.
+     *
+     * @return ResponseInterface
+     */
+    public function download($code): ResponseInterface;
+
     /**
      * Creates a new reference entity media file.
      *


### PR DESCRIPTION
The interface `DownloadableResourceInterface` cannot be used because the type of the return is not the same.