### PR TITLE
update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   },
   "require": {
-    "akeneo/api-php-client": "^5.0"
+    "akeneo/api-php-client": "^5.0 || ^6.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.14",
@@ -33,9 +33,6 @@
     "php-http/guzzle6-adapter": "^2.0"
   },
   "config": {
-    "bin-dir": "bin",
-    "platform": {
-      "php": "7.1.3"
-    }
+    "bin-dir": "bin"
   }
 }


### PR DESCRIPTION
- Allow akeneo/api-php-client: ^6.0
- removed config of platform faker. It's wrong fake platform version, it's useful only on local env to simulate a production environment if our host is not compatible with requirements.